### PR TITLE
Add basic PWA support.

### DIFF
--- a/ServiceWorker.js
+++ b/ServiceWorker.js
@@ -1,0 +1,45 @@
+const CACHE_NAME = 'offline';
+const OFFLINE_URL = 'offline.html';
+
+self.addEventListener('install', (event) => {
+	event.waitUntil((async () => {
+		const cache = await caches.open(CACHE_NAME);
+		console.log('Service Worker installed');
+		await cache.add(new Request(OFFLINE_URL, { cache: 'reload' }));
+	})());
+});
+
+
+self.addEventListener('activate', (event) => {
+	event.waitUntil((async () => {
+		console.log('Service Worker activated');
+	})());
+
+	if ('navigationPreload' in self.registration) {
+		await self.registration.navigationPreload.enable();
+	}
+
+	self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+	if (event.request.mode === 'navigate') {
+		event.respondWith((async () => {
+			try {
+				const preloadResponse = await event.preloadResponse;
+				if (preloadResponse) {
+					return preloadResponse;
+				}
+
+				const networkResponse = await fetch(event.request);
+				return networkResponse;
+			} catch (error) {
+				console.log('User Offline', error);
+
+				const cache = await caches.open(CACHE_NAME);
+				const cachedResponse = await cache.match(OFFLINE_URL);
+				return cachedResponse;
+			}
+		})());
+	}
+});

--- a/assets/manifest.webmanifest
+++ b/assets/manifest.webmanifest
@@ -1,0 +1,14 @@
+{
+	"name": "Glap3D.ga",
+	"short_name": "Glap3D",
+	"start_url": "/",
+	"display": "standalone",
+	"theme_color": "#320a8a",
+	"background_color": "#320a8a",
+	"description": "Glap.io in 3D",
+	"icons": [{
+	  "src": "/appletouchicon.png",
+	  "sizes": "192x192",
+	  "type": "image/png"
+	}]
+  }

--- a/assets/pwa.js
+++ b/assets/pwa.js
@@ -1,0 +1,3 @@
+if (serviceWorker in navigator) {
+	navigator.serviceWorker.register('./ServiceWorker.js');
+}

--- a/index.html
+++ b/index.html
@@ -18,7 +18,9 @@
     <script src="./assets/libs/three.min.js" defer></script>
     <!-- <script src="./assets/libs/postprocessing.min.js" async></script> -->
 	<script src="./assets/fire/fireshading.min.js" async></script>
+	<script src="./assets/pwa.js" async></script>
     <link href="./assets/main.css" rel="stylesheet" async>
+    <link href="./assets/manifest.webmanifest" rel="manifest" async>
 	<script src="./assets/game.js" defer></script>
 </head>
 <body>

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>An error occured.</title>
+	</head>
+	<body>
+		Glap3D cannot work offilne. Check your Internet connection and try again.
+	</body>
+</html>


### PR DESCRIPTION
Hi, I've added basic support for Progressive Web App and users now should be able to install the game as an app. I'm not sure that everything will work (I wrote it at 3:00 am and I didn't have time to check it out), but it should (remember, service workers which are requirement to make the app installable can run only in HTTPS pages). You can edit the files if I did something wrong (~~as usual~~).